### PR TITLE
Refactor/command buffer

### DIFF
--- a/command_buffer/command_buffer.py
+++ b/command_buffer/command_buffer.py
@@ -212,8 +212,10 @@ class CommandBuffer:
         self._write_final_commands_to_buffer(final_cmds)
 
     def show_status(self):
+        files = []
         for f in sorted(os.listdir(self.output_dir)):
-            print(f" - {f}")
+            files.append(f)
+        return files
 
     def get_commands(self):
         commands = []

--- a/tests/test_command_buffer.py
+++ b/tests/test_command_buffer.py
@@ -1,34 +1,36 @@
 from command_buffer.command_buffer import CommandBuffer
 
 
-def test_add_one_command(capsys):
+def test_add_one_command():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("W", "1", "0x12121212")
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_W_1_0x12121212\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+
+    assert cb.show_status() == ["1_W_1_0x12121212",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_three_command(capsys):
+def test_three_command():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("W", "1", "0x12121212")
     cb.add_command("W", "2", "0x12121212")
     cb.add_command("W", "3", "0x12121212")
+
     cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_W_1_0x12121212\n"
-                            " - 2_W_2_0x12121212\n"
-                            " - 3_W_3_0x12121212\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_W_1_0x12121212",
+                                "2_W_2_0x12121212",
+                                "3_W_3_0x12121212",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_more_five_command(capsys):
+def test_more_five_command():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("W", "1", "0x12121212")
     cb.add_command("W", "2", "0x12121212")
     cb.add_command("W", "3", "0x12121212")
@@ -37,272 +39,253 @@ def test_more_five_command(capsys):
     cb.add_command("W", "6", "0x12121212")
 
     cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_W_6_0x12121212\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_W_6_0x12121212",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_same_lba_write_command(capsys):
+def test_same_lba_write_command():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("W", "1", "0x12121212")
     cb.add_command("W", "1", "0xAAAAAAAA")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_W_1_0xAAAAAAAA\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_W_1_0xAAAAAAAA",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_same_lba_erase_command(capsys):
+def test_same_lba_erase_command():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "3")
     cb.add_command("E", "1", "3")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_3\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_3",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_same_lba_more_range_erase_command(capsys):
+def test_same_lba_more_range_erase_command():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "3")
     cb.add_command("E", "1", "5")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_5\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_5",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_erase_when_write_within_valid_range(capsys):
+def test_erase_when_write_within_valid_range():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("W", "3", "0x12345678")
     cb.add_command("E", "1", "5")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_5\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_5",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_erase_skipped_if_erase_invoked_before_valid_write(capsys):
+def test_erase_skipped_if_erase_invoked_before_valid_write():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "5")
     cb.add_command("W", "3", "0x12345678")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_5\n"
-                            " - 2_W_3_0x12345678\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_5",
+                                "2_W_3_0x12345678",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_merge_when_one_erase_contains_another(capsys):
+def test_merge_when_one_erase_contains_another():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "3", "3")
     cb.add_command("E", "1", "5")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_5\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_5",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_merge_when_erases_are_adjacent(capsys):
+def test_merge_when_erases_are_adjacent():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "3")
     cb.add_command("E", "4", "5")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_8\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_8",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_merge_when_erases_overlap(capsys):
+def test_merge_when_erases_overlap():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "5")
     cb.add_command("E", "3", "5")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_7\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_7",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_merge_rejected_when_resulting_erase_size_exceeds_ten(capsys):
+def test_merge_rejected_when_resulting_erase_size_exceeds_ten():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "6")
     cb.add_command("E", "5", "7")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_10\n"
-                            " - 2_E_11_1\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_10",
+                                "2_E_11_1",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_pdf_page30(capsys):
+def test_pdf_page30():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("W", "20", "0xABCDABCD")
     cb.add_command("W", "21", "0x12341234")
     cb.add_command("W", "20", "0xEEEEFFFF")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_W_21_0x12341234\n"
-                            " - 2_W_20_0xEEEEFFFF\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_W_21_0x12341234",
+                                "2_W_20_0xEEEEFFFF",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_pdf_page31(capsys):
+def test_pdf_page31():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "18", "3")
     cb.add_command("W", "21", "0x12341234")
     cb.add_command("E", "18", "5")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_18_5\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_18_5",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_pdf_page32(capsys):
+def test_pdf_page32():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("W", "20", "0xABCDABCD")
     cb.add_command("E", "10", "4")
     cb.add_command("E", "12", "3")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_W_20_0xABCDABCD\n"
-                            " - 2_E_10_5\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_W_20_0xABCDABCD",
+                                "2_E_10_5",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_merge_erases_when_intermediate_erase_added(capsys):
+def test_merge_erases_when_intermediate_erase_added():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "2")
     cb.add_command("E", "4", "4")
     cb.add_command("E", "2", "4")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_7\n"
-                            " - 2_empty\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_7",
+                                "2_empty",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_merge_fails_on_size_limit(capsys):
+def test_merge_fails_on_size_limit():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "5")
     cb.add_command("E", "12", "4")
     cb.add_command("E", "5", "8")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_10\n"
-                            " - 2_E_11_5\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_10",
+                                "2_E_11_5",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_erase_merge_with_write_lba_optimization_1(capsys):
+def test_erase_merge_with_write_lba_optimization_1():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "10")
     cb.add_command("E", "7", "10")
     cb.add_command("E", "12", "10")
     cb.add_command("W", "11", "0x12345678")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_10\n"
-                            " - 2_E_12_10\n"
-                            " - 3_W_11_0x12345678\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_10",
+                                "2_E_12_10",
+                                "3_W_11_0x12345678",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_erase_merge_with_write_lba_optimization_2(capsys):
+def test_erase_merge_with_write_lba_optimization_2():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "10")
     cb.add_command("E", "7", "10")
     cb.add_command("E", "16", "6")
     cb.add_command("W", "11", "0x12345678")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_10\n"
-                            " - 2_E_12_10\n"
-                            " - 3_W_11_0x12345678\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_10",
+                                "2_E_12_10",
+                                "3_W_11_0x12345678",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_write_outside_merged_erase_range_1(capsys):
+def test_write_outside_merged_erase_range_1():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "6")
     cb.add_command("E", "6", "6")
     cb.add_command("W", "1", "0x12345678")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_2_10\n"
-                            " - 2_W_1_0x12345678\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_2_10",
+                                "2_W_1_0x12345678",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]
 
 
-def test_write_outside_merged_erase_range_2(capsys):
+def test_write_outside_merged_erase_range_2():
     cb = CommandBuffer()
+    cb.initialize_buffer()
     cb.add_command("E", "1", "6")
     cb.add_command("E", "6", "6")
     cb.add_command("W", "11", "0x12345678")
 
-    cb.show_status()
-    captured = capsys.readouterr()
-    assert captured.out == (" - 1_E_1_10\n"
-                            " - 2_W_11_0x12345678\n"
-                            " - 3_empty\n"
-                            " - 4_empty\n"
-                            " - 5_empty\n")
+    assert cb.show_status() == ["1_E_1_10",
+                                "2_W_11_0x12345678",
+                                "3_empty",
+                                "4_empty",
+                                "5_empty"]


### PR DESCRIPTION
commad buffer 리펙토링
1. 메서드 분리 및 역할 명확화
    _get_active_commands(): 활성화된 명령 파일들을 가져와 파싱합니다.
    _prioritize_commands(): LBA별 최신 Write, 최대 크기 Erase 명령을 식별합니다.
    _filter_obsolete_writes(): 오래된 Write 명령을 필터링합니다.
    _merge_erases(): 인접한 Erase 명령을 병합합니다.
    _split_erases(): 병합된 Erase 명령을 지정된 크기(최대 10칸)로 분할합니다.
    _write_final_commands_to_buffer(): 최종 명령 목록을 파일로 저장합니다.
2. 변수 및 함수명 개선
    원래 코드의 ignore_command_optimization은 리팩토링 후 optimize_commands로 변경되었습니다. 이 변경은 메서드의 실제 기능(명령어를 최적화하는 것)을 더 정확하게 표현합니다. 또한, 내부적으로 사용되던 fname 같은 약식 변수들이 filename, new_fname 등 더 명확한 이름으로 바뀌었고, write_result와 같은 변수는 final_writes로 변경되어 최종 결과물을 나타내는 것을 더 명확히 합니다.
3. 중복 코드 제거
    원래 코드에서는 initialize_buffer와 유사한 초기화 로직이 __init__ 메서드와 flush 메서드에 나뉘어 있었습니다. 리팩토링된 코드에서는 initialize_buffer라는 전용 메서드를 만들어 중복을 제거하고, __init__과 flush 모두 이 메서드를 호출하도록 구조를 개선했습니다.
    
<img width="776" height="552" alt="image" src="https://github.com/user-attachments/assets/6efaf553-8121-433b-90e0-e368565247e3" />
