### PR TITLE
bugfix/erase_range-runtime-error

### DIFF
--- a/shell/command_validator.py
+++ b/shell/command_validator.py
@@ -68,7 +68,7 @@ class EraseRangeValidator(ArgumentValidator):
         if len(args) != 2:
             return False
         lba_start, lba_end = args
-        return is_valid_lba(lba_start) and lba_end.isdigit()
+        return is_valid_lba(lba_start) and bool(re.fullmatch(r"[0-9]+", lba_end))
 
 
 class FlushValidator(ArgumentValidator):


### PR DESCRIPTION
[bugfix] 유니코드 입력 방어
#45 버그 픽스

아래와 같이 유니코드 숫자가 입력으로 들어가도 INVALID COMMAND를 띄우도록 수정했습니다.

<img width="1387" height="166" alt="image" src="https://github.com/user-attachments/assets/35932bcf-1827-4f95-86a5-9d7b98be016a" />


<img width="2374" height="954" alt="image" src="https://github.com/user-attachments/assets/88b5f883-f9cc-44db-895f-bcb080792c5a" />
cf) 현재 test_driver_read가 실패하는데, 혜원님께 확인했을 때 커맨드 버퍼를 염두에 두지 않은 테스트라서 실패하고 있다고 합니다. 